### PR TITLE
add unicode support for OpenDialog

### DIFF
--- a/src/include/nfd.h
+++ b/src/include/nfd.h
@@ -40,6 +40,11 @@ nfdresult_t NFD_OpenDialog( const nfdchar_t *filterList,
                             const nfdchar_t *defaultPath,
                             nfdchar_t **outPath );
 
+/* single file open dialog */
+nfdresult_t NFD_OpenDialogWCHAR_T(const nfdchar_t *filterList,
+                                  const nfdchar_t *defaultPath,
+                                  wchar_t **outPath);
+
 /* multiple file open dialog */    
 nfdresult_t NFD_OpenDialogMultiple( const nfdchar_t *filterList,
                                     const nfdchar_t *defaultPath,


### PR DESCRIPTION
Created a function that instead of using nfdchar_t, it uses wchar_t as the output path